### PR TITLE
Change Hello label to white

### DIFF
--- a/GithubDemo/ViewController.swift
+++ b/GithubDemo/ViewController.swift
@@ -20,7 +20,7 @@ class ViewController: UIViewController {
         super.viewWillAppear(animated);
         
         self.view.backgroundColor = .blue
-        self.helloWorldLabel.textColor = .yellow
+        self.helloWorldLabel.textColor = .white
         self.helloWorldLabel.text = "Hello World"
     }
     


### PR DESCRIPTION
Designers and users agreed, the text should be white instead of yellow
for the hello world label.